### PR TITLE
Yarn Path

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,2 @@
 nodeLinker: node-modules
-yarnPath: .yarn/releases/yarn-3.2.1.cjs
+yarnPath: .yarn/releases/yarn-3.2.2.cjs

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
         "slugify": "^1.6.5"
     },
     "engines": {
-        "node": "16.14.0"
-    }
+        "node": "16.14.0",
+        "yarn": "3.2.2"
+    },
+    "packageManager": "yarn@3.2.2"
 }


### PR DESCRIPTION
 - Fix for the below deployment error

   


      Build failed

      Yarn was not found

      It looks like yarn is missing from .yarn/releases/yarn-3.2.1.cjs, which is needed to continue

      this build on Heroku. Yarn 2 recommends vendoring Yarn under the '.yarn/releases'

      directory, so remember to check the '.yarn' directory into version control

      to use during builds.



